### PR TITLE
chore: bump version to 0.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "bchaddrjs",
+  "name": "@exodus/bchaddrjs",
   "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "bchaddrjs",
+      "name": "@exodus/bchaddrjs",
       "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
-        "bs58check": "^2.1.2",
+        "bs58check": "^3.0.0",
         "cashaddrjs": "^0.3.3"
       },
       "devDependencies": {
@@ -25,7 +25,7 @@
         "nyc": "^13.3.0",
         "shelljs": "^0.8.2",
         "standard": "^10.0.3",
-        "uglify-js": "^3.4.7"
+        "uglify-js": "^3.19.0"
       },
       "engines": {
         "node": ">= 6.0.0"
@@ -229,6 +229,18 @@
       "dev": true,
       "dependencies": {
         "acorn": "^5.2.1"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/acorn": {
@@ -502,12 +514,10 @@
       "dev": true
     },
     "node_modules/base-x": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
-      "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
+      "license": "MIT"
     },
     "node_modules/base64-js": {
       "version": "1.2.1",
@@ -766,27 +776,23 @@
       "dev": true
     },
     "node_modules/bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
       "dependencies": {
-        "base-x": "^3.0.2"
+        "base-x": "^4.0.0"
       }
     },
     "node_modules/bs58check": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-3.0.1.tgz",
+      "integrity": "sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==",
+      "license": "MIT",
       "dependencies": {
-        "bs58": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "safe-buffer": "^5.1.2"
+        "@noble/hashes": "^1.2.0",
+        "bs58": "^5.0.0"
       }
-    },
-    "node_modules/bs58check/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/buffer": {
       "version": "5.0.8",
@@ -927,6 +933,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -1148,6 +1155,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
+      "dev": true,
       "dependencies": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -2273,6 +2281,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.1"
       }
@@ -2411,7 +2420,8 @@
     "node_modules/inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "node_modules/inline-source-map": {
       "version": "0.6.2",
@@ -5311,6 +5321,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+      "dev": true,
       "dependencies": {
         "hash-base": "^2.0.0",
         "inherits": "^2.0.1"
@@ -5340,7 +5351,8 @@
     "node_modules/safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -5361,6 +5373,7 @@
       "version": "2.4.9",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz",
       "integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -5840,34 +5853,16 @@
       "dev": true
     },
     "node_modules/uglify-js": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.7.tgz",
-      "integrity": "sha512-J0M2i1mQA+ze3EdN9SBi751DNdAXmeFLfJrd/MDIkRc3G3Gbb9OPVSx7GIQvVwfWxQARcYV2DTxIkMyDAk3o9Q==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
       "dev": true,
-      "dependencies": {
-        "commander": "~2.16.0",
-        "source-map": "~0.6.1"
-      },
+      "license": "BSD-2-Clause",
       "bin": {
         "uglifyjs": "bin/uglifyjs"
       },
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/uglify-js/node_modules/commander": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
-      "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew==",
-      "dev": true
-    },
-    "node_modules/uglify-js/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/umd": {

--- a/package.json
+++ b/package.json
@@ -58,10 +58,10 @@
     "nyc": "^13.3.0",
     "shelljs": "^0.8.2",
     "standard": "^10.0.3",
-    "uglify-js": "^3.4.7"
+    "uglify-js": "^3.19.0"
   },
   "dependencies": {
-    "bs58check": "^2.1.2",
+    "bs58check": "^3.0.0",
     "cashaddrjs": "^0.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/bchaddrjs",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Bitcoin Cash general purpose address translation.",
   "main": "src/bchaddr.js",
   "scripts": {


### PR DESCRIPTION
- Updates bs58check from ^2.1.2 to ^3.0.0 to resolve crypto dependency issues
- Updates uglify-js from ^3.4.7 to ^3.19.0 for ES6+ compatibility
- Bumped to 0.3.3